### PR TITLE
added auto install for colorspacious

### DIFF
--- a/figure_notebooks/Fig_3_hue_sensitivity.ipynb
+++ b/figure_notebooks/Fig_3_hue_sensitivity.ipynb
@@ -13,6 +13,14 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: colorspacious in /Users/melian/miniconda3/envs/ANNPsych/lib/python3.8/site-packages (1.1.2)\n",
+      "Requirement already satisfied: numpy in /Users/melian/miniconda3/envs/ANNPsych/lib/python3.8/site-packages (from colorspacious) (1.24.3)\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
@@ -22,6 +30,8 @@
     }
    ],
    "source": [
+    "!pip install colorspacious\n",
+    "\n",
     "import sys,os,warnings\n",
     "import numpy as np\n",
     "import torch\n",


### PR DESCRIPTION
colorspacious is needed for generating hue plot, but is not available by default on Google Colab